### PR TITLE
Fix README typo (in output of `video_acl.to_a`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ end
 
 video_acl.to_a
 # =>
-# [#<Verifica::Ace:0x00007fab1955dd60 @action=:view, @allow=true, @sid="authenticated">,          
-#  #<Verifica::Ace:0x00007fab1955dd10 @action=:comment, @allow=true, @sid="authenticated">,       
-#  #<Verifica::Ace:0x00007fab1955dc48 @action=:view, @allow=false, @sid="country:US">]
+# [#<Verifica::Ace:0x00007fab1955dd60 @action=:read, @allow=true, @sid="authenticated">,
+#  #<Verifica::Ace:0x00007fab1955dd10 @action=:comment, @allow=true, @sid="authenticated">,
+#  #<Verifica::Ace:0x00007fab1955dc48 @action=:read, @allow=false, @sid="country:US">]
 ```
 
 ### AclProvider


### PR DESCRIPTION
This fixes a minor typo in the README's illustrated output of calling `video_acl.to_a`. Prior to this PR, the output referred to an action called "`view`", but in the code the action is (now) called "`read`", and so the illustrated output should show `read` (rather than `view`).